### PR TITLE
Fix Netlify deploys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,11 +78,8 @@ jobs:
       - <<: *restore_cache
       - <<: *install_npm_packages
       - run:
-          name: Install Netlify CLI
-          command: sudo npm install netlify-cli -g
-      - run:
           name: Deploy preview to Netlify
-          command: netlify deploy --dir=/home/circleci/project/build --auth=$NETLIFY_AUTH_TOKEN --site=$NETLIFY_SITE_ID
+          command: npx netlify-cli deploy --dir=/home/circleci/project/build --auth=$NETLIFY_AUTH_TOKEN --site=$NETLIFY_SITE_ID
 
   release:
     <<: *defaults
@@ -93,11 +90,8 @@ jobs:
       - <<: *restore_cache
       - <<: *install_npm_packages
       - run:
-          name: Install Netlify CLI
-          command: sudo npm install netlify-cli -g
-      - run:
           name: Deploy site to Netlify
-          command: netlify deploy --prod --dir=/home/circleci/project/build --auth=$NETLIFY_AUTH_TOKEN --site=$NETLIFY_SITE_ID
+          command: npx netlify-cli deploy --prod --dir=/home/circleci/project/build --auth=$NETLIFY_AUTH_TOKEN --site=$NETLIFY_SITE_ID
 
 workflows:
   version: 2


### PR DESCRIPTION
Instead of installing `netlify-cli` globally, we use `npx` to deploy to Netlify. This fixes #15.